### PR TITLE
Allow copying of URL field value

### DIFF
--- a/imports/ui/templates/finalize.html
+++ b/imports/ui/templates/finalize.html
@@ -2,7 +2,7 @@
     <div class="row">
         <div class="col-md-6">
             <h3>Open following link or scan qrcode to join:</h3>
-            <input type="text" class="answer-link input-lg" value="{{ getAnswerUrl }}" disabled="true">
+            <input type="text" class="answer-link input-lg" value="{{ getAnswerUrl }}" readonly>
             <div class="qr-code"></div>
         </div>
         <div class="col-md-6">


### PR DESCRIPTION
The URL field currently is `disabled`, which makes it impossible to copy the URL and use it elsewhere, e. g. in an email.

This PR changes the field to read-only, which allows for selecting and copying the URL.